### PR TITLE
add ng cloak css rule as we load angular lazily

### DIFF
--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -216,3 +216,8 @@ body {
   width: 100%;
   background-color: #fff;
 }
+
+
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+  display: none !important;
+}


### PR DESCRIPTION
original this is embedded in angular.min.js, but we need this explicitly as we load angular lazily
